### PR TITLE
pre-commit: add detect-private-key and check-merge-conflict hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
       - id: end-of-file-fixer
       # Replaces or checks mixed line ending.
       - id: mixed-line-ending
+      # Detect strings that look like private keys.
+      - id: detect-private-key
+      # Check for files that contain merge conflict strings.
+      - id: check-merge-conflict
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:


### PR DESCRIPTION
Add two safety hooks from the already-configured pre-commit/pre-commit-hooks repo (no new dependency needed):

- detect-private-key: catches accidental commits of RSA/EC/etc. private keys, complementing the existing SOPS/forbid-secrets check which targets K8s Secret manifests but not raw key material.
- check-merge-conflict: prevents committing files that still contain conflict markers (<<<<<<, ======, >>>>>>>), a common mistake after resolving conflicts in large kustomization stacks.