### PR TITLE
pre-commit: add check-yaml hook for YAML syntax validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,10 @@ repos:
       - id: detect-private-key
       # Check for files that contain merge conflict strings.
       - id: check-merge-conflict
+      # Validate YAML syntax in all YAML files.
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+        exclude: ^apps/.*\.enc\.yaml$
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:


### PR DESCRIPTION
## Summary
- Adds `check-yaml` hook from `pre-commit-hooks` to validate YAML syntax on all YAML files
- Uses `--allow-multiple-documents` to support multi-document YAML files
- Excludes `apps/**/*.enc.yaml` (SOPS-encrypted files) which aren't valid YAML without decryption

## Test plan
- [ ] Run `pre-commit run check-yaml --all-files` to verify no false positives
- [ ] Confirm encrypted `.enc.yaml` files are excluded