### PR TITLE
feat(analyzers): migrate to anthropic-sdk-go, update image digests

### DIFF
--- a/apps/claude-alert-checkmk-analyzer/k8s.deployment.yaml
+++ b/apps/claude-alert-checkmk-analyzer/k8s.deployment.yaml
@@ -30,13 +30,24 @@ spec:
           type: RuntimeDefault
       containers:
         - name: analyzer
-          image: ghcr.io/madic-creates/claude-alert-checkmk-analyzer:latest@sha256:85c3c9f9b5c57aba9b394b3143a92b1f5c675558b753aa119f910f32ecc10f53
+          image: ghcr.io/madic-creates/claude-alert-checkmk-analyzer:latest@sha256:3295184d656a571f2b8e8d88201b4aea487b6b29357ac200919ed86594d20ad3
           ports:
             - containerPort: 8080
               name: http
           envFrom:
             - secretRef:
                 name: claude-alert-checkmk-analyzer-env
+          env:
+            - name: ANTHROPIC_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: claude-alert-checkmk-analyzer-env
+                  key: API_KEY
+            - name: ANTHROPIC_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: claude-alert-checkmk-analyzer-env
+                  key: API_BASE_URL
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/apps/claude-alert-kubernetes-analyzer/k8s.deployment.yaml
+++ b/apps/claude-alert-kubernetes-analyzer/k8s.deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: analyzer
-          image: ghcr.io/madic-creates/claude-alert-kubernetes-analyzer:latest@sha256:ee06e7dbc0cc48e30e33987288626bd88f8442e874dfd665235a35887e427dfc
+          image: ghcr.io/madic-creates/claude-alert-kubernetes-analyzer:latest@sha256:c2f57084d5a062fe3a7a665bf8d95dd6a0997cb5c0e4a76188e11ddf4ef28fdd
           ports:
             - containerPort: 8080
               name: http
@@ -51,12 +51,12 @@ spec:
               value: "monitoring,databases,media,kube-system"
             - name: MAX_LOG_BYTES
               value: "2048"
-            - name: API_KEY
+            - name: ANTHROPIC_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: claude-alert-kubernetes-analyzer-env
                   key: API_KEY
-            - name: API_BASE_URL
+            - name: ANTHROPIC_BASE_URL
               valueFrom:
                 secretKeyRef:
                   name: claude-alert-kubernetes-analyzer-env


### PR DESCRIPTION
## Summary

Updates both Claude analyzer deployments to use the new `anthropic-sdk-go`-based images from [madic-creates/claude-alert-analyzer#10](https://github.com/madic-creates/claude-alert-analyzer/pull/10).

**claude-alert-kubernetes-analyzer**
- Rename env var `API_KEY` → `ANTHROPIC_AUTH_TOKEN` (OpenRouter Bearer token auth)
- Rename env var `API_BASE_URL` → `ANTHROPIC_BASE_URL`
- Update image digest → `44da4d2`

**claude-alert-checkmk-analyzer**
- Add explicit env vars `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` mapping from existing secret keys `API_KEY` / `API_BASE_URL`
- Update image digest → `44da4d2`